### PR TITLE
feat: FE-BE 페르소나 연동 및 테스트 로그인 구현

### DIFF
--- a/BE/app/api/routes/auth.py
+++ b/BE/app/api/routes/auth.py
@@ -12,7 +12,8 @@ from app.schemas.auth import (
     TokensResponse,
     RefreshResponse,
     LogoutResponse,
-    RefreshTokenRequest
+    RefreshTokenRequest,
+    TestLoginRequest
 )
 from app.services.google_oauth import GoogleOAuthService
 from app.services.auth_service import AuthService
@@ -188,3 +189,119 @@ async def logout(
         )
     
     return LogoutResponse(ok=True)
+
+
+# =============================================================================
+# 테스트용 로그인 (개발/시연용 - 프로덕션에서 제거)
+# =============================================================================
+TEST_USER_EMAIL = "test@test.com"
+TEST_USER_NAME = "테스트 유저"
+TEST_CHANNEL_ID = "UCfBvs0ZJdTA43NQrnI9imGA"  # 코딩알려주는누나
+
+
+@router.post("/test-login", response_model=LoginResponse)
+async def test_login(
+    request_data: TestLoginRequest,
+    response: Response,
+    request: Request,
+    db: AsyncSession = Depends(get_db)
+):
+    """
+    테스트용 로그인 (개발/시연용).
+
+    - username: test
+    - password: 1234
+    - "코딩알려주는누나" 채널로 테스트
+    """
+    # 자격 증명 확인
+    if request_data.username != "test" or request_data.password != "1234":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid test credentials"
+        )
+
+    try:
+        from sqlalchemy import select
+        from app.models.youtube_channel import YouTubeChannel
+        from datetime import datetime
+
+        # 테스트 유저 조회 또는 생성
+        result = await db.execute(
+            select(User).where(User.email == TEST_USER_EMAIL)
+        )
+        user = result.scalar_one_or_none()
+
+        if not user:
+            # 테스트 유저 생성
+            user = User(
+                email=TEST_USER_EMAIL,
+                name=TEST_USER_NAME,
+                google_sub="test_google_sub",
+                avatar_url=None,
+            )
+            db.add(user)
+            await db.commit()
+            await db.refresh(user)
+
+        # 테스트 채널 연결 확인
+        result = await db.execute(
+            select(YouTubeChannel).where(YouTubeChannel.user_id == user.id)
+        )
+        channel = result.scalar_one_or_none()
+
+        if not channel:
+            # 테스트 채널 연결
+            channel = YouTubeChannel(
+                channel_id=TEST_CHANNEL_ID,
+                user_id=user.id,
+                title="코딩알려주는누나",
+                description="코딩 교육 채널",
+                raw_channel_json={"test": True},
+                created_at=datetime.utcnow(),
+                updated_at=datetime.utcnow(),
+            )
+            db.add(channel)
+            await db.commit()
+
+        # 세션 생성
+        user_agent = request.headers.get("user-agent")
+        client_host = request.client.host if request.client else None
+        session = await AuthService.create_session(db, user.id, user_agent, client_host)
+
+        # 쿠키 설정
+        response.set_cookie(
+            key="session_token",
+            value=session.session_token,
+            httponly=True,
+            secure=settings.cookie_secure,
+            samesite=settings.cookie_samesite,
+            max_age=settings.session_ttl_sec,
+            domain=settings.cookie_domain if settings.cookie_domain != "localhost" else None,
+            path="/"
+        )
+
+        # JWT 토큰 생성
+        access_token = create_access_token(str(user.id), user.email)
+        jti, refresh_token = await AuthService.create_jwt_refresh_token(db, user.id)
+
+        return LoginResponse(
+            user=UserResponse(
+                user_id=user.id,
+                email=user.email,
+                name=user.name,
+                avatar_url=user.avatar_url
+            ),
+            tokens=TokensResponse(
+                access_token=access_token,
+                refresh_token=refresh_token,
+                expires_in_sec=settings.access_token_ttl_sec
+            )
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Test login failed: {str(e)}"
+        )

--- a/BE/app/schemas/auth.py
+++ b/BE/app/schemas/auth.py
@@ -15,6 +15,12 @@ class RefreshTokenRequest(BaseModel):
     refresh_token: str
 
 
+class TestLoginRequest(BaseModel):
+    """Request schema for test login (development only)."""
+    username: str
+    password: str
+
+
 # Response schemas
 class UserResponse(BaseModel):
     """User response schema."""

--- a/BE/app/services/persona_llm_analyzer.py
+++ b/BE/app/services/persona_llm_analyzer.py
@@ -8,12 +8,13 @@ Gemini API를 사용하여 채널 콘텐츠를 분석합니다.
 2. 히트 vs 저조 영상 비교 → 성공 요인, 피해야 할 방향
 3. 채널 설명 분석 → 정체성, 브랜딩 수준
 """
-import os
 import json
 from typing import List, Optional
 from dataclasses import dataclass, asdict
 
 import httpx
+
+from app.core.config import settings
 
 
 # Gemini API 설정
@@ -106,7 +107,7 @@ async def analyze_video_titles(titles: List[str]) -> Optional[TitleAnalysisResul
     Returns:
         TitleAnalysisResult or None
     """
-    api_key = os.getenv("GEMINI_API_KEY")
+    api_key = settings.gemini_api_key
     if not api_key:
         print("GEMINI_API_KEY not set")
         return None
@@ -185,7 +186,7 @@ async def analyze_hit_vs_low(
     Returns:
         HitVsLowResult or None
     """
-    api_key = os.getenv("GEMINI_API_KEY")
+    api_key = settings.gemini_api_key
     if not api_key:
         return None
 
@@ -261,7 +262,7 @@ async def analyze_channel_description(
     Returns:
         DescriptionAnalysisResult or None
     """
-    api_key = os.getenv("GEMINI_API_KEY")
+    api_key = settings.gemini_api_key
     if not api_key:
         return None
 
@@ -365,7 +366,7 @@ async def analyze_channel_categories(
     Returns:
         CategoryAnalysisResult or None
     """
-    api_key = os.getenv("GEMINI_API_KEY")
+    api_key = settings.gemini_api_key
     if not api_key:
         print("GEMINI_API_KEY not set")
         return None

--- a/BE/seed_test_data.py
+++ b/BE/seed_test_data.py
@@ -1,0 +1,196 @@
+"""
+테스트용 더미 데이터 시딩 스크립트
+
+실행 방법:
+    cd BE
+    python seed_test_data.py
+
+생성되는 데이터:
+    - yt_audience_daily: 시청자 인구통계 (나이/성별)
+    - yt_geo_daily: 지역별 통계
+    - yt_channel_stats_daily: 채널 일별 통계
+"""
+import asyncio
+from datetime import date, datetime, timedelta
+from uuid import uuid4
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config import settings
+
+
+# 코딩알려주는누나 채널 ID
+TEST_CHANNEL_ID = "UCfBvs0ZJdTA43NQrnI9imGA"  # 코딩알려주는누나
+
+
+async def seed_test_data():
+    """테스트용 더미 데이터 삽입."""
+
+    # DB 연결
+    engine = create_async_engine(settings.database_url, echo=True)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as db:
+        today = date.today()
+        now = datetime.utcnow()
+
+        # 기존 테스트 데이터 삭제
+        await db.execute(text(f"DELETE FROM yt_audience_daily WHERE channel_id = '{TEST_CHANNEL_ID}'"))
+        await db.execute(text(f"DELETE FROM yt_geo_daily WHERE channel_id = '{TEST_CHANNEL_ID}'"))
+        await db.execute(text(f"DELETE FROM yt_channel_stats_daily WHERE channel_id = '{TEST_CHANNEL_ID}'"))
+        await db.commit()
+
+        print("기존 테스트 데이터 삭제 완료")
+
+        # =================================================================
+        # 0. 테스트 유저 + 채널 생성 (FK 제약 조건 충족)
+        # =================================================================
+        TEST_USER_EMAIL = "test@test.com"
+
+        # 테스트 유저 확인/생성
+        result = await db.execute(text(f"SELECT id FROM users WHERE email = '{TEST_USER_EMAIL}'"))
+        user_row = result.fetchone()
+
+        if user_row:
+            test_user_id = user_row[0]
+            print(f"기존 테스트 유저 발견: {test_user_id}")
+        else:
+            test_user_id = str(uuid4())
+            await db.execute(text("""
+                INSERT INTO users (id, email, name, google_sub, created_at, updated_at)
+                VALUES (:id, :email, :name, :google_sub, :created_at, :updated_at)
+            """), {
+                "id": test_user_id,
+                "email": TEST_USER_EMAIL,
+                "name": "테스트 유저",
+                "google_sub": "test_google_sub",
+                "created_at": now,
+                "updated_at": now,
+            })
+            print(f"테스트 유저 생성: {test_user_id}")
+
+        # 테스트 채널 확인/생성
+        result = await db.execute(text(f"SELECT channel_id FROM youtube_channels WHERE channel_id = '{TEST_CHANNEL_ID}'"))
+        channel_row = result.fetchone()
+
+        if not channel_row:
+            await db.execute(text("""
+                INSERT INTO youtube_channels (channel_id, user_id, title, description, raw_channel_json, created_at, updated_at)
+                VALUES (:channel_id, :user_id, :title, :description, :raw_channel_json, :created_at, :updated_at)
+            """), {
+                "channel_id": TEST_CHANNEL_ID,
+                "user_id": test_user_id,
+                "title": "코딩알려주는누나",
+                "description": "코딩 교육 채널",
+                "raw_channel_json": '{"test": true}',
+                "created_at": now,
+                "updated_at": now,
+            })
+            print(f"테스트 채널 생성: {TEST_CHANNEL_ID}")
+        else:
+            print(f"기존 테스트 채널 발견: {TEST_CHANNEL_ID}")
+
+        await db.commit()
+
+        # =================================================================
+        # 1. yt_audience_daily (시청자 인구통계)
+        # =================================================================
+        audience_data = [
+            # 남성
+            {"age_group": "13-17", "gender": "male", "viewer_percentage": 5.0},
+            {"age_group": "18-24", "gender": "male", "viewer_percentage": 25.0},
+            {"age_group": "25-34", "gender": "male", "viewer_percentage": 35.0},
+            {"age_group": "35-44", "gender": "male", "viewer_percentage": 10.0},
+            {"age_group": "45-54", "gender": "male", "viewer_percentage": 3.0},
+            # 여성
+            {"age_group": "13-17", "gender": "female", "viewer_percentage": 2.0},
+            {"age_group": "18-24", "gender": "female", "viewer_percentage": 10.0},
+            {"age_group": "25-34", "gender": "female", "viewer_percentage": 8.0},
+            {"age_group": "35-44", "gender": "female", "viewer_percentage": 2.0},
+        ]
+
+        for data in audience_data:
+            await db.execute(text("""
+                INSERT INTO yt_audience_daily
+                (id, channel_id, date, age_group, gender, viewer_percentage, created_at)
+                VALUES (:id, :channel_id, :date, :age_group, :gender, :viewer_percentage, :created_at)
+            """), {
+                "id": str(uuid4()),
+                "channel_id": TEST_CHANNEL_ID,
+                "date": today,
+                "age_group": data["age_group"],
+                "gender": data["gender"],
+                "viewer_percentage": data["viewer_percentage"],
+                "created_at": now,
+            })
+
+        print(f"yt_audience_daily: {len(audience_data)}개 삽입 완료")
+
+        # =================================================================
+        # 2. yt_geo_daily (지역별 통계)
+        # =================================================================
+        geo_data = [
+            {"country": "KR", "viewer_percentage": 82.0},
+            {"country": "US", "viewer_percentage": 8.0},
+            {"country": "JP", "viewer_percentage": 3.0},
+            {"country": "VN", "viewer_percentage": 2.0},
+            {"country": "TW", "viewer_percentage": 1.5},
+            {"country": "CA", "viewer_percentage": 1.0},
+            {"country": "AU", "viewer_percentage": 0.8},
+            {"country": "GB", "viewer_percentage": 0.7},
+        ]
+
+        for data in geo_data:
+            await db.execute(text("""
+                INSERT INTO yt_geo_daily
+                (id, channel_id, date, country, viewer_percentage, created_at)
+                VALUES (:id, :channel_id, :date, :country, :viewer_percentage, :created_at)
+            """), {
+                "id": str(uuid4()),
+                "channel_id": TEST_CHANNEL_ID,
+                "date": today,
+                "country": data["country"],
+                "viewer_percentage": data["viewer_percentage"],
+                "created_at": now,
+            })
+
+        print(f"yt_geo_daily: {len(geo_data)}개 삽입 완료")
+
+        # =================================================================
+        # 3. yt_channel_stats_daily (채널 일별 통계)
+        # =================================================================
+        # 최근 30일치 데이터 생성
+        base_subscribers = 450000
+        base_views = 50000000
+        base_videos = 200
+
+        for i in range(30):
+            stat_date = today - timedelta(days=i)
+            # 약간의 변동 추가
+            subscribers = base_subscribers + (i * 100)  # 매일 100명씩 증가 가정
+            views = base_views + (i * 50000)
+
+            await db.execute(text("""
+                INSERT INTO yt_channel_stats_daily
+                (id, channel_id, date, subscriber_count, view_count, video_count, created_at)
+                VALUES (:id, :channel_id, :date, :subscriber_count, :view_count, :video_count, :created_at)
+            """), {
+                "id": str(uuid4()),
+                "channel_id": TEST_CHANNEL_ID,
+                "date": stat_date,
+                "subscriber_count": subscribers,
+                "view_count": views,
+                "video_count": base_videos,
+                "created_at": now,
+            })
+
+        print(f"yt_channel_stats_daily: 30개 삽입 완료")
+
+        await db.commit()
+        print("\n✅ 테스트 더미 데이터 시딩 완료!")
+
+
+if __name__ == "__main__":
+    asyncio.run(seed_test_data())

--- a/FE/src/lib/api/services/auth.service.ts
+++ b/FE/src/lib/api/services/auth.service.ts
@@ -29,3 +29,12 @@ export const refreshToken = async (refreshTokenValue: string): Promise<RefreshTo
     });
     return response.data;
 };
+
+// 테스트 로그인 (개발/시연용)
+export const testLogin = async (username: string, password: string): Promise<LoginResponse> => {
+    const response = await api.post('/auth/test-login', {
+        username,
+        password,
+    });
+    return response.data;
+};

--- a/FE/src/lib/api/services/index.ts
+++ b/FE/src/lib/api/services/index.ts
@@ -3,3 +3,4 @@ export * from './auth.service';
 export * from './youtube.service';
 export * from './competitor.service';
 export * from './subtitle.service';
+export * from './persona.service';

--- a/FE/src/lib/api/services/persona.service.ts
+++ b/FE/src/lib/api/services/persona.service.ts
@@ -1,0 +1,20 @@
+import { api } from '../client';
+import type { PersonaResponse, PersonaGenerateResponse, PersonaUpdateRequest } from '../types';
+
+// 내 페르소나 조회
+export const getMyPersona = async (): Promise<PersonaResponse> => {
+    const response = await api.get('/personas/me');
+    return response.data;
+};
+
+// 페르소나 생성 (채널 분석)
+export const generatePersona = async (): Promise<PersonaGenerateResponse> => {
+    const response = await api.post('/personas/generate');
+    return response.data;
+};
+
+// 페르소나 수정 (선호 카테고리 저장 등)
+export const updatePersona = async (data: PersonaUpdateRequest): Promise<PersonaResponse> => {
+    const response = await api.patch('/personas/me', data);
+    return response.data;
+};

--- a/FE/src/lib/api/types/index.ts
+++ b/FE/src/lib/api/types/index.ts
@@ -3,3 +3,4 @@ export * from './auth.types';
 export * from './youtube.types';
 export * from './competitor.types';
 export * from './subtitle.types';
+export * from './persona.types';

--- a/FE/src/lib/api/types/persona.types.ts
+++ b/FE/src/lib/api/types/persona.types.ts
@@ -1,0 +1,69 @@
+// 페르소나 응답 타입
+export interface PersonaResponse {
+    id: string;
+    channel_id: string;
+
+    // 종합 서술
+    persona_summary?: string;
+
+    // 정체성
+    one_liner?: string;
+    main_topics?: string[];
+    content_style?: string;
+    differentiator?: string;
+
+    // 타겟 시청자
+    target_audience?: string;
+    audience_needs?: string;
+
+    // 성공 공식
+    hit_topics?: string[];
+    title_patterns?: string[];
+    optimal_duration?: string;
+
+    // 성장 기회
+    growth_opportunities?: string[];
+
+    // 근거
+    evidence?: any[];
+
+    // 카테고리 (분석 결과 + 사용자 선택)
+    analyzed_categories?: string[];
+    analyzed_subcategories?: string[];
+    preferred_categories?: string[];
+    preferred_subcategories?: string[];
+
+    // 매칭용 키워드
+    topic_keywords?: string[];
+    style_keywords?: string[];
+
+    // 메타
+    created_at?: string;
+    updated_at?: string;
+}
+
+// 페르소나 생성 응답
+export interface PersonaGenerateResponse {
+    success: boolean;
+    message: string;
+    persona?: PersonaResponse;
+}
+
+// 페르소나 수정 요청
+export interface PersonaUpdateRequest {
+    persona_summary?: string;
+    one_liner?: string;
+    main_topics?: string[];
+    content_style?: string;
+    differentiator?: string;
+    target_audience?: string;
+    audience_needs?: string;
+    hit_topics?: string[];
+    title_patterns?: string[];
+    optimal_duration?: string;
+    growth_opportunities?: string[];
+    topic_keywords?: string[];
+    style_keywords?: string[];
+    preferred_categories?: string[];
+    preferred_subcategories?: string[];
+}

--- a/FE/src/pages/onboarding/page.tsx
+++ b/FE/src/pages/onboarding/page.tsx
@@ -1,14 +1,17 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
+import { useNavigate } from "react-router-dom"
 import { Button } from "../../components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "../../components/ui/card"
 import { Input } from "../../components/ui/input"
 import { Label } from "../../components/ui/label"
 import { RadioGroup, RadioGroupItem } from "../../components/ui/radio-group"
 import { Slider } from "../../components/ui/slider"
-import { Play, ChevronRight, ChevronLeft, Check, Gamepad2, BookOpen, Utensils, Dumbbell, Palette, Music, Camera, Briefcase, Tv } from "lucide-react"
+import { Play, ChevronRight, ChevronLeft, Check, Gamepad2, BookOpen, Utensils, Dumbbell, Palette, Music, Camera, Briefcase, Tv, Loader2 } from "lucide-react"
 import { Link } from "react-router-dom"
+import { generatePersona, updatePersona } from "../../lib/api"
+import type { PersonaResponse } from "../../lib/api/types"
 
 const categories = [
   { id: "gaming", label: "게임", icon: Gamepad2 },
@@ -23,13 +26,84 @@ const categories = [
 ]
 
 export default function OnboardingPage() {
+  const navigate = useNavigate()
+
+  // 기존 상태 (Step 2, 3용 - 나중에 활용 가능)
   const [step, setStep] = useState(1)
   const [channelName, setChannelName] = useState("")
-  const [selectedCategory, setSelectedCategory] = useState("")
   const [uploadFrequency, setUploadFrequency] = useState([2])
   const [targetAudience, setTargetAudience] = useState("")
 
-  const totalSteps = 3
+  // 새로운 상태 (페르소나 연동)
+  const [isAnalyzing, setIsAnalyzing] = useState(true)
+  const [persona, setPersona] = useState<PersonaResponse | null>(null)
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+
+  const totalSteps = 1  // 현재는 1단계만 사용
+
+  // 페이지 진입 시 페르소나 생성
+  useEffect(() => {
+    const analyzeChannel = async () => {
+      try {
+        setIsAnalyzing(true)
+        setError(null)
+
+        const response = await generatePersona()
+
+        if (response.success && response.persona) {
+          setPersona(response.persona)
+        } else {
+          setError(response.message || "채널 분석에 실패했습니다.")
+        }
+      } catch (err: any) {
+        console.error("페르소나 생성 실패:", err)
+        setError(err.response?.data?.detail || "채널 분석 중 오류가 발생했습니다.")
+      } finally {
+        setIsAnalyzing(false)
+      }
+    }
+
+    analyzeChannel()
+  }, [])
+
+  // 카테고리 복수 선택 토글
+  const toggleCategory = (categoryId: string) => {
+    setSelectedCategories(prev =>
+      prev.includes(categoryId)
+        ? prev.filter(id => id !== categoryId)
+        : [...prev, categoryId]
+    )
+  }
+
+  // 시작하기 클릭 (선호 카테고리 저장 후 대시보드 이동)
+  const handleStart = async () => {
+    try {
+      setIsSaving(true)
+
+      if (selectedCategories.length > 0) {
+        await updatePersona({
+          preferred_categories: selectedCategories
+        })
+      }
+
+      navigate('/dashboard')
+    } catch (err: any) {
+      console.error("카테고리 저장 실패:", err)
+      navigate('/dashboard')  // 실패해도 대시보드로 이동
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  // 분석된 카테고리 텍스트
+  const getAnalyzedCategoryText = () => {
+    if (!persona?.analyzed_categories || persona.analyzed_categories.length === 0) {
+      return "Education / Tech"
+    }
+    return persona.analyzed_categories.join(", ")
+  }
 
   const handleNext = () => {
     if (step < totalSteps) {
@@ -70,46 +144,87 @@ export default function OnboardingPage() {
           {step === 1 && (
             <>
               <CardHeader className="text-center">
-                <CardTitle className="text-2xl">채널 정보를 알려주세요</CardTitle>
+                <CardTitle className="text-2xl">
+                  {isAnalyzing ? "채널을 분석하고 있어요" : error ? "분석 중 문제가 발생했어요" : "안녕하세요!"}
+                </CardTitle>
                 <CardDescription>
-                  맞춤형 콘텐츠 추천을 위해 채널 정보가 필요해요
+                  {isAnalyzing
+                    ? "잠시만 기다려 주세요..."
+                    : error
+                    ? error
+                    : "최적의 맞춤 서비스를 위해 몇 가지만 더 확인할게요"}
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-6">
-                <div className="space-y-2">
-                  <Label htmlFor="channel-name">채널 이름</Label>
-                  <Input
-                    id="channel-name"
-                    placeholder="내 채널 이름"
-                    value={channelName}
-                    onChange={(e) => setChannelName(e.target.value)}
-                    className="h-12"
-                  />
-                </div>
-
-                <div className="space-y-4">
-                  <Label>채널 카테고리</Label>
-                  <div className="grid grid-cols-3 gap-3">
-                    {categories.map((category) => {
-                      const Icon = category.icon
-                      return (
-                        <button
-                          key={category.id}
-                          onClick={() => setSelectedCategory(category.id)}
-                          className={`p-4 rounded-xl border transition-all flex flex-col items-center gap-2 ${selectedCategory === category.id
-                            ? "border-primary bg-primary/10"
-                            : "border-border/50 hover:border-primary/50 hover:bg-muted/50"
-                            }`}
-                        >
-                          <Icon className={`w-6 h-6 ${selectedCategory === category.id ? "text-primary" : "text-muted-foreground"}`} />
-                          <span className={`text-sm font-medium ${selectedCategory === category.id ? "text-primary" : "text-foreground"}`}>
-                            {category.label}
-                          </span>
-                        </button>
-                      )
-                    })}
+                {/* 로딩 상태 */}
+                {isAnalyzing && (
+                  <div className="flex flex-col items-center justify-center py-12">
+                    <Loader2 className="w-16 h-16 text-primary animate-spin mb-6" />
+                    <p className="text-muted-foreground text-center">
+                      채널의 영상 데이터를 분석하여<br />
+                      맞춤형 콘텐츠를 추천해 드릴게요
+                    </p>
                   </div>
-                </div>
+                )}
+
+                {/* 에러 상태 */}
+                {!isAnalyzing && error && (
+                  <div className="flex flex-col items-center justify-center py-8">
+                    <Button
+                      onClick={() => window.location.reload()}
+                      className="bg-primary hover:bg-primary/90"
+                    >
+                      다시 시도하기
+                    </Button>
+                  </div>
+                )}
+
+                {/* 분석 완료 상태 */}
+                {!isAnalyzing && !error && (
+                  <>
+                    {/* 분석 결과 표시 (채널 이름 입력 대신) */}
+                    <div className="p-4 rounded-xl bg-primary/10 border border-primary/20">
+                      <div className="flex items-start gap-3">
+                        <div className="w-10 h-10 rounded-lg bg-primary/20 flex items-center justify-center flex-shrink-0">
+                          <Check className="w-5 h-5 text-primary" />
+                        </div>
+                        <div>
+                          <p className="font-semibold text-foreground">분석 결과</p>
+                          <p className="text-sm text-muted-foreground mt-1">
+                            현재 채널의 카테고리는 <span className="text-primary font-medium">{getAnalyzedCategoryText()}</span> 입니다.
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* 선호 카테고리 선택 (복수 선택) */}
+                    <div className="space-y-4">
+                      <Label>선호 카테고리 <span className="text-muted-foreground font-normal">(복수 선택 가능)</span></Label>
+                      <p className="text-sm text-muted-foreground">원하는 카테고리가 있다면 선택해 주세요.</p>
+                      <div className="grid grid-cols-3 gap-3">
+                        {categories.map((category) => {
+                          const Icon = category.icon
+                          const isSelected = selectedCategories.includes(category.id)
+                          return (
+                            <button
+                              key={category.id}
+                              onClick={() => toggleCategory(category.id)}
+                              className={`p-4 rounded-xl border transition-all flex flex-col items-center gap-2 ${isSelected
+                                ? "border-primary bg-primary/10"
+                                : "border-border/50 hover:border-primary/50 hover:bg-muted/50"
+                                }`}
+                            >
+                              <Icon className={`w-6 h-6 ${isSelected ? "text-primary" : "text-muted-foreground"}`} />
+                              <span className={`text-sm font-medium ${isSelected ? "text-primary" : "text-foreground"}`}>
+                                {category.label}
+                              </span>
+                            </button>
+                          )
+                        })}
+                      </div>
+                    </div>
+                  </>
+                )}
               </CardContent>
             </>
           )}
@@ -198,30 +313,28 @@ export default function OnboardingPage() {
             </>
           )}
 
-          <div className="p-6 pt-0 flex justify-between">
-            <Button
-              variant="outline"
-              onClick={handleBack}
-              disabled={step === 1}
-              className="gap-2 bg-transparent"
-            >
-              <ChevronLeft className="w-4 h-4" />
-              이전
-            </Button>
-            {step < totalSteps ? (
-              <Button onClick={handleNext} className="gap-2 bg-primary hover:bg-primary/90">
-                다음
-                <ChevronRight className="w-4 h-4" />
+          {/* 하단 버튼 - 분석 완료 후에만 표시 */}
+          {!isAnalyzing && !error && (
+            <div className="p-6 pt-0 flex justify-end">
+              <Button
+                onClick={handleStart}
+                disabled={isSaving}
+                className="gap-2 bg-primary hover:bg-primary/90"
+              >
+                {isSaving ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    저장 중...
+                  </>
+                ) : (
+                  <>
+                    시작하기
+                    <Check className="w-4 h-4" />
+                  </>
+                )}
               </Button>
-            ) : (
-              <Link to="/dashboard">
-                <Button className="gap-2 bg-primary hover:bg-primary/90">
-                  시작하기
-                  <Check className="w-4 h-4" />
-                </Button>
-              </Link>
-            )}
-          </div>
+            </div>
+          )}
         </Card>
       </main>
     </div>


### PR DESCRIPTION
BE:
- 테스트 로그인 엔드포인트 추가 (test / 1234)
- 페르소나 서비스 버그 수정 (subscriber_count, race condition)
- GEMINI_API_KEY settings 연동 수정
- 채널 영상 수집 race condition 처리
- 테스트 데이터 시딩 스크립트 추가

FE:
- 페르소나 API 서비스 및 타입 추가
- 테스트 로그인 기능 추가
- 온보딩 페이지 페르소나 생성 플로우 연동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 테스트 계정(test/1234)을 이용한 로그인 기능 추가
  * 페르소나 생성 및 관리 기능 구현
  * 로그인 후 페르소나 자동 확인 및 대시보드/온보딩 자동 라우팅
  * 온보딩 단계에서 AI 분석 기반 카테고리 다중 선택 기능

* **개선 사항**
  * 로그인 및 온보딩 워크플로우 최적화
  * 데이터베이스 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->