### PR TITLE
feat: 인용 문장 하이라이트 + 스크립트 품질 개선

### DIFF
--- a/BE/app/worker.py
+++ b/BE/app/worker.py
@@ -102,6 +102,12 @@ def task_generate_script(self, topic: str, channel_profile: dict, topic_request_
         # (Celery worker에서 기존 이벤트 루프 충돌 방지)
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
+        
+        # ★ 이전 task에서 닫힌 루프에 바인딩된 DB 커넥션 풀 초기화
+        # (안 하면 stale 커넥션 재사용 → 'NoneType' has no attribute 'send' 에러)
+        from app.core.db import engine
+        loop.run_until_complete(engine.dispose())
+        
         try:
             # TopicRequest가 없으면 생성
             if not topic_request_id:


### PR DESCRIPTION
## 변경 사항

### FE: 인용 문장 하이라이트 (script-editor.tsx)
- 인용 마커(①②③) 직전의 **문장만** 하이라이트 표시
- 숫자 내 마침표(4.99, 14.79) 문장 경계 오인식 방지
- 마커가 마침표 앞에 오는 패턴(하거든요 ①.) 정확히 처리
- makeBadge 헬퍼 함수로 뱃지 생성 중복 코드 제거
- extractText에서 cite-highlight span 정확히 역변환

### BE: 스크립트 생성 품질 개선
- writer 노드: 인용 후처리 로직 개선
- insight_builder 노드 개선
- worker 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 인용문 마커 시스템 추가: 순환형 번호(①, ②, ③ 등)를 사용하여 일관된 인용문 형식 제공
  * 출처별 팩트 구성 개선: 각 기사별 최소 1개 이상의 팩트 보장, 최대 15개까지 표시

* **버그 수정**
  * 생성된 텍스트의 인용문 번호 정확성 개선
  * 고아 팩트(미연결 팩트) 방지 메커니즘 추가

* **스타일**
  * 인용문 배지 시각적 표현 개선
  * 인용된 텍스트 강조 표시 기능 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->