### PR TITLE
feat: 채널 분석 페이지 탭 추가 + Gemini 429 해결 + Branch B 처리

### DIFF
--- a/BE/app/services/video_analyzer.py
+++ b/BE/app/services/video_analyzer.py
@@ -96,21 +96,29 @@ def sample_transcript(transcript: str) -> str:
     긴 자막을 앞+중간+뒤에서 샘플링하여 축약.
 
     5000자 이하: 그대로 반환
-    5000자 초과: 앞 1500자 + 중간 1500자 + 뒤 2000자 = 5000자
+    5000자 초과: 구분자 포함 정확히 MAX_TRANSCRIPT_LENGTH 이내로 샘플링
 
-    - 앞: 인트로/훅/인사말 패턴
-    - 중간: 본론 전개 방식
-    - 뒤: 마무리/CTA 패턴
+    - 앞 (~30%): 인트로/훅/인사말 패턴
+    - 중간 (~30%): 본론 전개 방식
+    - 뒤 (~40%): 마무리/CTA 패턴
     """
     if len(transcript) <= MAX_TRANSCRIPT_LENGTH:
         return transcript
 
-    front = transcript[:1500]
-    mid_start = (len(transcript) - 1500) // 2
-    middle = transcript[mid_start:mid_start + 1500]
-    back = transcript[-2000:]
+    separator = "\n\n[...중간 생략...]\n\n"
+    sep_total = len(separator) * 2
+    budget = MAX_TRANSCRIPT_LENGTH - sep_total
 
-    return f"{front}\n\n[...중간 생략...]\n\n{middle}\n\n[...중간 생략...]\n\n{back}"
+    front_len = int(budget * 0.30)
+    mid_len = int(budget * 0.30)
+    back_len = budget - front_len - mid_len
+
+    front = transcript[:front_len]
+    mid_start = (len(transcript) - mid_len) // 2
+    middle = transcript[mid_start:mid_start + mid_len]
+    back = transcript[-back_len:]
+
+    return f"{front}{separator}{middle}{separator}{back}"
 
 
 # ============================================================================
@@ -929,7 +937,7 @@ async def analyze_hit_vs_low_comparison(
 
     from langchain_openai import ChatOpenAI
 
-    llm = ChatOpenAI(model="gpt-4o", api_key=openai_key, temperature=0.3)
+    llm = ChatOpenAI(model="gpt-4o", api_key=openai_key, temperature=0.3, timeout=60, max_retries=0)
     logger.info("[VideoAnalyzer] 비교 분석: GPT-4o 사용")
 
     for attempt in range(max_retries):

--- a/BE/app/services/video_analyzer.py
+++ b/BE/app/services/video_analyzer.py
@@ -943,7 +943,11 @@ async def analyze_hit_vs_low_comparison(
     for attempt in range(max_retries):
         try:
             response = await llm.ainvoke(prompt)
-            text = response.content.strip()
+            raw = response.content
+            if isinstance(raw, list):
+                text = "".join(block.get("text", "") if isinstance(block, dict) else str(block) for block in raw).strip()
+            else:
+                text = str(raw).strip()
 
             # JSON 파싱
             text = re.sub(r'^```json\s*', '', text)

--- a/BE/app/services/video_analyzer.py
+++ b/BE/app/services/video_analyzer.py
@@ -86,6 +86,34 @@ class ChannelVideoSummary:
 
 
 # ============================================================================
+# 자막 샘플링 (긴 자막 → 앞+중간+뒤 추출)
+# ============================================================================
+
+MAX_TRANSCRIPT_LENGTH = 5000  # 이 길이 이하면 그대로 사용
+
+def sample_transcript(transcript: str) -> str:
+    """
+    긴 자막을 앞+중간+뒤에서 샘플링하여 축약.
+
+    5000자 이하: 그대로 반환
+    5000자 초과: 앞 1500자 + 중간 1500자 + 뒤 2000자 = 5000자
+
+    - 앞: 인트로/훅/인사말 패턴
+    - 중간: 본론 전개 방식
+    - 뒤: 마무리/CTA 패턴
+    """
+    if len(transcript) <= MAX_TRANSCRIPT_LENGTH:
+        return transcript
+
+    front = transcript[:1500]
+    mid_start = (len(transcript) - 1500) // 2
+    middle = transcript[mid_start:mid_start + 1500]
+    back = transcript[-2000:]
+
+    return f"{front}\n\n[...중간 생략...]\n\n{middle}\n\n[...중간 생략...]\n\n{back}"
+
+
+# ============================================================================
 # Performance Score 계산
 # ============================================================================
 
@@ -559,7 +587,7 @@ async def analyze_videos_batch(
         except Exception as e:
             logger.error(f"[VideoAnalyzer] hit 배치 실패: {e}")
 
-        await asyncio.sleep(10.0)  # Gemini rate limit 방지
+        await asyncio.sleep(20.0)  # Gemini rate limit 방지 (TPM 고려)
 
     # 2. low 배치 분석 (개별 분석 + 공통 패턴 + 말투 후보)
     if low_videos:
@@ -574,7 +602,7 @@ async def analyze_videos_batch(
         except Exception as e:
             logger.error(f"[VideoAnalyzer] low 배치 실패: {e}")
 
-        await asyncio.sleep(10.0)  # Gemini rate limit 방지
+        await asyncio.sleep(20.0)  # Gemini rate limit 방지 (TPM 고려)
 
     # 3. latest 배치 분석 (개별 분석 + 공통 패턴 + 말투 후보)
     if latest_videos:
@@ -607,6 +635,9 @@ async def _analyze_batch_with_llm(
     # 프롬프트 구성
     videos_text = ""
     for idx, (video, transcript) in enumerate(batch, 1):
+        # 자막 샘플링 (긴 자막 → 앞+중간+뒤 추출)
+        sampled = sample_transcript(transcript)
+
         # 댓글 텍스트 구성
         comments = comments_map.get(video.id, [])
         comments_text = ""
@@ -627,7 +658,7 @@ async def _analyze_batch_with_llm(
 - 길이: {video.duration_seconds // 60}분 {video.duration_seconds % 60}초
 
 자막:
-{transcript}
+{sampled}
 
 시청자 댓글 (좋아요 순 상위):
 {comments_text if comments_text else "(댓글 없음)"}
@@ -811,9 +842,9 @@ async def analyze_hit_vs_low_comparison(
         low_viewer_data = []
     if latest_viewer_data is None:
         latest_viewer_data = []
-    api_key = settings.gemini_api_key
-    if not api_key:
-        logger.error("[VideoAnalyzer] Gemini API 키 없음")
+    openai_key = settings.openai_api_key
+    if not openai_key:
+        logger.error("[VideoAnalyzer] OpenAI API 키 없음 (비교 분석용)")
         return {"tone_manner": "", "tone_samples": [], "success_formula": "", "viewer_likes": [], "viewer_dislikes": [], "current_viewer_needs": []}
 
     if not hit_patterns and not low_patterns and not tone_candidates:
@@ -896,77 +927,52 @@ async def analyze_hit_vs_low_comparison(
 - current_viewer_needs: 최신 영상 댓글을 중심으로 현재 시청자가 원하는 것 3-5개 (가장 중요!)
 """
 
+    from langchain_openai import ChatOpenAI
+
+    llm = ChatOpenAI(model="gpt-4o", api_key=openai_key, temperature=0.3)
+    logger.info("[VideoAnalyzer] 비교 분석: GPT-4o 사용")
+
     for attempt in range(max_retries):
         try:
-            async with httpx.AsyncClient(timeout=60.0) as client:
-                resp = await client.post(
-                    f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key={api_key}",
-                    json={
-                        "contents": [{"parts": [{"text": prompt}]}],
-                        "generationConfig": {
-                            "temperature": 0.3,
-                            "maxOutputTokens": 2048,
-                            "responseMimeType": "application/json",
-                        },
-                    },
-                )
+            response = await llm.ainvoke(prompt)
+            text = response.content.strip()
 
-                if resp.status_code == 429:
-                    wait_time = (attempt + 1) * 5  # 5초, 10초, 15초
-                    logger.warning(f"[VideoAnalyzer] 비교 분석 429 에러, {wait_time}초 대기 후 재시도 ({attempt+1}/{max_retries})")
-                    await asyncio.sleep(wait_time)
-                    continue
+            # JSON 파싱
+            text = re.sub(r'^```json\s*', '', text)
+            text = re.sub(r'^```\s*', '', text)
+            text = re.sub(r'\s*```$', '', text)
 
-                if resp.status_code != 200:
-                    logger.error(f"[VideoAnalyzer] 비교 분석 API 에러: {resp.status_code}")
-                    return {"tone_manner": "", "tone_samples": [], "success_formula": "", "viewer_likes": [], "viewer_dislikes": [], "current_viewer_needs": []}
+            response_data = json.loads(text)
 
-                data = resp.json()
-                candidates = data.get("candidates", [])
-                if not candidates:
-                    logger.error("[VideoAnalyzer] 비교 분석 응답에 candidates 없음")
-                    return {"tone_manner": "", "tone_samples": [], "success_formula": "", "viewer_likes": [], "viewer_dislikes": [], "current_viewer_needs": []}
+            success_formula = response_data.get("success_formula", "")
+            tone_manner = response_data.get("tone_manner", "")
+            tone_samples = response_data.get("tone_samples", [])
+            viewer_likes = response_data.get("viewer_likes", [])
+            viewer_dislikes = response_data.get("viewer_dislikes", [])
+            current_viewer_needs = response_data.get("current_viewer_needs", [])
 
-                text = candidates[0]["content"]["parts"][0]["text"]
+            logger.info(
+                f"[VideoAnalyzer] 비교 분석 완료 (GPT-4o): "
+                f"성공공식 있음={bool(success_formula)}, "
+                f"tone_manner 있음={bool(tone_manner)}, "
+                f"tone_samples={len(tone_samples)}개, "
+                f"viewer_likes={len(viewer_likes)}개, "
+                f"viewer_dislikes={len(viewer_dislikes)}개, "
+                f"current_needs={len(current_viewer_needs)}개"
+            )
 
-                # JSON 파싱
-                text = text.strip()
-                text = re.sub(r'^```json\s*', '', text)
-                text = re.sub(r'^```\s*', '', text)
-                text = re.sub(r'\s*```$', '', text)
-
-                response_data = json.loads(text)
-
-                success_formula = response_data.get("success_formula", "")
-                tone_manner = response_data.get("tone_manner", "")
-                tone_samples = response_data.get("tone_samples", [])
-                # 시청자 분석 (NEW)
-                viewer_likes = response_data.get("viewer_likes", [])
-                viewer_dislikes = response_data.get("viewer_dislikes", [])
-                current_viewer_needs = response_data.get("current_viewer_needs", [])
-
-                logger.info(
-                    f"[VideoAnalyzer] 비교 분석 완료: "
-                    f"성공공식 있음={bool(success_formula)}, "
-                    f"tone_manner 있음={bool(tone_manner)}, "
-                    f"tone_samples={len(tone_samples)}개, "
-                    f"viewer_likes={len(viewer_likes)}개, "
-                    f"viewer_dislikes={len(viewer_dislikes)}개, "
-                    f"current_needs={len(current_viewer_needs)}개"
-                )
-
-                return {
-                    "tone_manner": tone_manner,
-                    "tone_samples": tone_samples,
-                    "success_formula": success_formula,
-                    "viewer_likes": viewer_likes,
-                    "viewer_dislikes": viewer_dislikes,
-                    "current_viewer_needs": current_viewer_needs,
-                }
+            return {
+                "tone_manner": tone_manner,
+                "tone_samples": tone_samples,
+                "success_formula": success_formula,
+                "viewer_likes": viewer_likes,
+                "viewer_dislikes": viewer_dislikes,
+                "current_viewer_needs": current_viewer_needs,
+            }
 
         except (json.JSONDecodeError, Exception) as e:
             error_type = "JSON 파싱 실패" if isinstance(e, json.JSONDecodeError) else "분석 실패"
-            logger.error(f"[VideoAnalyzer] 비교 분석 {error_type}: {e}")
+            logger.error(f"[VideoAnalyzer] 비교 분석 {error_type} (GPT-4o): {e}")
             if attempt < max_retries - 1:
                 wait_time = (attempt + 1) * 5
                 logger.warning(f"[VideoAnalyzer] 비교 분석 {wait_time}초 대기 후 재시도")
@@ -1246,8 +1252,7 @@ async def analyze_channel_videos(
         else:  # latest
             latest_viewer_data.append(viewer_item)
 
-    # 4. 비교 분석 (success_formula + tone_manner + tone_samples + 시청자 분석)
-    await asyncio.sleep(10.0)  # Gemini rate limit 방지
+    # 4. 비교 분석 (success_formula + tone_manner + tone_samples + 시청자 분석) - GPT-4o 사용
     comparison_result = await analyze_hit_vs_low_comparison(
         hit_patterns=hit_patterns,
         low_patterns=low_patterns,

--- a/FE/src/pages/analysis/components/my-channel-tab.tsx
+++ b/FE/src/pages/analysis/components/my-channel-tab.tsx
@@ -72,7 +72,7 @@ export function MyChannelTab() {
   }
 
   const mainTopics = persona.main_topics || []
-  const contentStyles = persona.content_style ? persona.content_style.split(",") : []
+  const contentStyles = persona.content_style ? persona.content_style.split(",").map(s => s.trim()).filter(Boolean) : []
   const toneSamples = persona.tone_samples || []
   const hitPatterns = persona.hit_patterns || []
   const videoTypes = persona.video_types || {}

--- a/FE/src/pages/analysis/components/my-channel-tab.tsx
+++ b/FE/src/pages/analysis/components/my-channel-tab.tsx
@@ -1,0 +1,263 @@
+"use client"
+
+import { useNavigate } from "react-router-dom"
+import { Loader2, Users, Target, Sparkles, TrendingUp, Video } from "lucide-react"
+import { Button } from "../../../components/ui/button"
+import { useQuery } from "@tanstack/react-query"
+import { getMyPersona } from "../../../lib/api/services"
+import {
+  SectionCard,
+  SectionHeader,
+  ToggleSection,
+} from "../../onboarding/components/channel-analysis-result"
+
+export function MyChannelTab() {
+  const navigate = useNavigate()
+  const { data: persona, isLoading, isError } = useQuery({
+    queryKey: ["my-persona"],
+    queryFn: getMyPersona,
+    staleTime: 1000 * 60 * 10,
+  })
+
+  /* 로딩 */
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <Loader2 className="w-8 h-8 animate-spin text-primary" />
+      </div>
+    )
+  }
+
+  /* 에러 또는 데이터 없음 */
+  if (isError || !persona) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <Users className="w-12 h-12 text-muted-foreground mb-4" />
+        <h3 className="font-medium text-foreground mb-2">
+          아직 채널 분석이 완료되지 않았습니다
+        </h3>
+        <p className="text-sm text-muted-foreground max-w-[300px]">
+          온보딩에서 채널 분석을 먼저 진행해주세요
+        </p>
+      </div>
+    )
+  }
+
+  /* Branch B: 자막 분석 데이터가 없는 경우 (수동 온보딩) */
+  const hasDetailedAnalysis = !!(
+    persona.tone_manner ||
+    persona.success_formula ||
+    (persona.video_types && Object.keys(persona.video_types).length > 0)
+  )
+
+  if (!hasDetailedAnalysis) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <Video className="w-12 h-12 text-muted-foreground mb-4" />
+        <h3 className="font-medium text-foreground mb-2">
+          아직 정보가 충분하지 않아요
+        </h3>
+        <p className="text-sm text-muted-foreground max-w-[340px] mb-6">
+          영상이 좀 더 쌓인다면 분석할 수 있어요!<br />
+          저와 함께 만들어 봐요
+        </p>
+        <Button
+          onClick={() => navigate("/explore")}
+          className="rounded-xl px-6 py-3 text-sm font-semibold bg-gradient-to-br from-[#2D2DFF] to-primary text-primary-foreground hover:shadow-[0_8px_32px_rgba(107,92,255,0.35)] hover:-translate-y-0.5 transition-all"
+        >
+          주제 탐색하러 가기
+        </Button>
+      </div>
+    )
+  }
+
+  const mainTopics = persona.main_topics || []
+  const contentStyles = persona.content_style ? persona.content_style.split(",") : []
+  const toneSamples = persona.tone_samples || []
+  const hitPatterns = persona.hit_patterns || []
+  const videoTypes = persona.video_types || {}
+  const contentStructures = persona.content_structures || {}
+  const growthOpportunities = persona.growth_opportunities || []
+
+  return (
+    <div className="max-w-[900px] mx-auto py-6 space-y-6">
+      {/* 헤더: 채널명 + 주제 태그 */}
+      <header>
+        <h2 className="text-2xl font-extrabold tracking-tight text-foreground mb-2">
+          {persona.one_liner || "내 채널"}
+        </h2>
+        {mainTopics.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2">
+            {mainTopics.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-3 py-1 rounded-md bg-primary/10 border border-primary/20 text-primary text-xs font-medium"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </header>
+
+      {/* Section 1: 채널 요약 */}
+      {persona.persona_summary && (
+        <section>
+          <SectionCard>
+            <SectionHeader
+              title="채널 요약"
+              subtitle="AI가 분석한 채널의 전체적인 특성이에요"
+            />
+            <p className="text-sm text-muted-foreground leading-relaxed mb-4">
+              {persona.persona_summary}
+            </p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {persona.target_audience && (
+                <div className="flex items-start gap-3 p-3 rounded-lg bg-blue-500/5 border border-blue-500/15">
+                  <Target className="w-4 h-4 text-blue-500 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="text-xs font-medium text-blue-500 mb-1">타겟 시청자</p>
+                    <p className="text-sm text-muted-foreground">{persona.target_audience}</p>
+                  </div>
+                </div>
+              )}
+              {persona.differentiator && (
+                <div className="flex items-start gap-3 p-3 rounded-lg bg-purple-500/5 border border-purple-500/15">
+                  <Sparkles className="w-4 h-4 text-purple-500 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="text-xs font-medium text-purple-500 mb-1">차별화 포인트</p>
+                    <p className="text-sm text-muted-foreground">{persona.differentiator}</p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </SectionCard>
+        </section>
+      )}
+
+      {/* Section 2: 톤앤매너 */}
+      {(contentStyles.length > 0 || toneSamples.length > 0) && (
+        <section>
+          <SectionCard>
+            <SectionHeader
+              title="톤앤매너"
+              subtitle="채널의 말투 패턴을 학습했어요"
+            />
+            <div className="bg-primary/5 border border-primary/10 rounded-lg p-4 mb-4">
+              {contentStyles.length > 0 && (
+                <div className="flex flex-wrap gap-2 mb-3">
+                  {contentStyles.map((style) => (
+                    <span
+                      key={style.trim()}
+                      className="inline-flex items-center px-3 py-1.5 rounded-md bg-primary/10 border border-primary/20 text-primary text-xs font-medium"
+                    >
+                      {style.trim()}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {toneSamples.length > 0 && (
+                <div className="space-y-1.5">
+                  {toneSamples.slice(0, 3).map((sample) => (
+                    <p
+                      key={sample}
+                      className="text-[13px] text-muted-foreground leading-relaxed"
+                    >
+                      &ldquo;{sample}&rdquo;
+                    </p>
+                  ))}
+                </div>
+              )}
+            </div>
+            {persona.tone_manner && (
+              <ToggleSection title="어떻게 분석했나요?">
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  {persona.tone_manner}
+                </p>
+              </ToggleSection>
+            )}
+          </SectionCard>
+        </section>
+      )}
+
+      {/* Section 3: 콘텐츠 구조 */}
+      {(persona.success_formula || hitPatterns.length > 0) && (
+        <section>
+          <SectionCard>
+            <SectionHeader
+              title="콘텐츠 구조"
+              subtitle="조회수가 높았던 영상의 공통 패턴을 분석했어요"
+            />
+            <div className="relative rounded-lg p-4 mb-4 overflow-hidden bg-gradient-to-r from-primary/10 to-green-500/5 border border-primary/20">
+              <div className="h-0.5 bg-gradient-to-r from-primary to-green-500 rounded-full mb-3" />
+              <p className="text-xs text-muted-foreground uppercase font-medium tracking-wider mb-2">
+                성공 공식
+              </p>
+              {hitPatterns.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mb-3">
+                  {hitPatterns.slice(0, 3).map((pattern) => (
+                    <span
+                      key={pattern}
+                      className="inline-flex items-center px-2.5 py-1 rounded-md bg-[rgba(255,255,255,0.06)] border border-[rgba(255,255,255,0.1)] text-xs font-medium text-foreground/80"
+                    >
+                      {pattern}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {persona.success_formula && (
+                <p className="text-sm font-semibold text-foreground leading-relaxed">
+                  {persona.success_formula}
+                </p>
+              )}
+            </div>
+            {Object.keys(videoTypes).length > 0 && (
+              <ToggleSection title="어떻게 분석했나요?">
+                <div className="space-y-4">
+                  {Object.entries(videoTypes)
+                    .sort(([, a], [, b]) => b - a)
+                    .map(([type, percent]) => (
+                      <div key={type}>
+                        <div className="flex items-center gap-2 mb-1">
+                          <span className="text-sm font-semibold text-foreground">{type}</span>
+                          <span className="text-xs text-muted-foreground">({percent}%)</span>
+                        </div>
+                        {contentStructures[type] && (
+                          <p className="text-xs text-muted-foreground leading-relaxed pl-1">
+                            {contentStructures[type]}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                </div>
+              </ToggleSection>
+            )}
+          </SectionCard>
+        </section>
+      )}
+
+      {/* Section 4: 성장 기회 */}
+      {growthOpportunities.length > 0 && (
+        <section>
+          <SectionCard>
+            <SectionHeader
+              title="성장 기회"
+              subtitle="채널이 더 성장할 수 있는 방향이에요"
+            />
+            <div className="space-y-3">
+              {growthOpportunities.map((opportunity, idx) => (
+                <div
+                  key={idx}
+                  className="flex items-start gap-3 p-3 rounded-lg bg-green-500/5 border border-green-500/15"
+                >
+                  <TrendingUp className="w-4 h-4 text-green-500 mt-0.5 shrink-0" />
+                  <p className="text-sm text-muted-foreground">{opportunity}</p>
+                </div>
+              ))}
+            </div>
+          </SectionCard>
+        </section>
+      )}
+    </div>
+  )
+}

--- a/FE/src/pages/analysis/page.tsx
+++ b/FE/src/pages/analysis/page.tsx
@@ -7,6 +7,8 @@ import { Button } from "../../components/ui/button"
 import { Badge } from "../../components/ui/badge"
 import { Avatar, AvatarFallback, AvatarImage } from "../../components/ui/avatar"
 import { ScrollArea } from "../../components/ui/scroll-area"
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "../../components/ui/tabs"
+import { MyChannelTab } from "./components/my-channel-tab"
 import { Users, Search, Loader2, Plus, Sparkles, CheckCircle2, AlertTriangle, Lightbulb, MessageSquare } from "lucide-react"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import {
@@ -308,6 +310,28 @@ export default function AnalysisPage() {
             </p>
           </div>
 
+          {/* 탭 */}
+          <Tabs defaultValue="my-channel">
+            <TabsList className="w-full h-12 bg-muted/50 border border-border/50 rounded-xl p-1">
+              <TabsTrigger
+                value="my-channel"
+                className="flex-1 h-full rounded-lg text-sm font-semibold data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-md transition-all"
+              >
+                내 채널 분석
+              </TabsTrigger>
+              <TabsTrigger
+                value="competitor"
+                className="flex-1 h-full rounded-lg text-sm font-semibold data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-md transition-all"
+              >
+                경쟁 채널 분석
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="my-channel">
+              <MyChannelTab />
+            </TabsContent>
+
+            <TabsContent value="competitor">
           {/* 경쟁 유튜버 분석 */}
           <div className="space-y-6">
               <Card className="border-border/50 bg-card/50 backdrop-blur">
@@ -533,6 +557,8 @@ export default function AnalysisPage() {
                 </CardContent>
               </Card>
           </div>
+            </TabsContent>
+          </Tabs>
         </div>
       </main>
     </div>

--- a/FE/src/pages/analysis/page.tsx
+++ b/FE/src/pages/analysis/page.tsx
@@ -108,6 +108,7 @@ function VideoAnalysisResults({ video }: { video: CompetitorChannelVideo }) {
 }
 
 export default function AnalysisPage() {
+  const [activeTab, setActiveTab] = useState("my-channel")
   const [searchQuery, setSearchQuery] = useState("")
   const [shouldSearch, setShouldSearch] = useState(false)
   const [analyzingVideoId, setAnalyzingVideoId] = useState<string | null>(null)
@@ -122,7 +123,7 @@ export default function AnalysisPage() {
     staleTime: 1000 * 60 * 5,
   })
 
-  // 등록된 경쟁 채널 목록
+  // 등록된 경쟁 채널 목록 (경쟁 채널 탭일 때만 조회)
   const { data: competitorList, isLoading: isLoadingList, error: listError } = useQuery({
     queryKey: ['competitor-channels'],
     queryFn: async () => {
@@ -132,6 +133,7 @@ export default function AnalysisPage() {
       return result
     },
     staleTime: 1000 * 60 * 5,
+    enabled: activeTab === "competitor",
   })
 
   // 페이지 진입 시 최신 영상 자동 갱신 (분석 중이 아닐 때만 invalidate)
@@ -149,8 +151,10 @@ export default function AnalysisPage() {
   })
 
   useEffect(() => {
-    refreshMutation.mutate()
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+    if (activeTab === "competitor") {
+      refreshMutation.mutate()
+    }
+  }, [activeTab]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // 경쟁 채널 추가 mutation
   const addMutation = useMutation({
@@ -311,7 +315,7 @@ export default function AnalysisPage() {
           </div>
 
           {/* 탭 */}
-          <Tabs defaultValue="my-channel">
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
             <TabsList className="w-full h-12 bg-muted/50 border border-border/50 rounded-xl p-1">
               <TabsTrigger
                 value="my-channel"

--- a/FE/src/pages/onboarding/components/channel-analysis-result.tsx
+++ b/FE/src/pages/onboarding/components/channel-analysis-result.tsx
@@ -34,11 +34,11 @@ export interface AnalysisResultData {
 }
 
 /* Section Card */
-interface SectionCardProps {
+export interface SectionCardProps {
   children: React.ReactNode
 }
 
-function SectionCard({ children }: SectionCardProps) {
+export function SectionCard({ children }: SectionCardProps) {
   return (
     <div className="rounded-xl border border-[rgba(255,255,255,0.06)] bg-[rgba(255,255,255,0.02)] p-5 md:p-6">
       {children}
@@ -47,12 +47,12 @@ function SectionCard({ children }: SectionCardProps) {
 }
 
 /* Section Header */
-interface SectionHeaderProps {
+export interface SectionHeaderProps {
   title: string
   subtitle: string
 }
 
-function SectionHeader({ title, subtitle }: SectionHeaderProps) {
+export function SectionHeader({ title, subtitle }: SectionHeaderProps) {
   return (
     <div className="mb-5">
       <h2 className="text-lg font-bold text-foreground mb-1">{title}</h2>
@@ -62,12 +62,12 @@ function SectionHeader({ title, subtitle }: SectionHeaderProps) {
 }
 
 /* 토글 섹션 */
-interface ToggleSectionProps {
+export interface ToggleSectionProps {
   title: string
   children: React.ReactNode
 }
 
-function ToggleSection({ title, children }: ToggleSectionProps) {
+export function ToggleSection({ title, children }: ToggleSectionProps) {
   const [isOpen, setIsOpen] = useState(false)
 
   const handleToggle = () => {


### PR DESCRIPTION
- /analysis 페이지에 "내 채널 분석" / "경쟁 채널 분석" 탭 추가
- 내 채널 분석 탭: 페르소나 기반 채널 요약, 톤앤매너, 콘텐츠 구조, 성장 기회 표시
- Branch B(수동 온보딩) 사용자에게 안내 메시지 + 주제 탐색 버튼 표시
- 긴 자막 샘플링(5000자 제한)으로 Gemini TPM 초과 방지
- 비교 분석을 GPT-4o로 전환하여 Gemini 부하 분산

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 탭식 인터페이스 추가: "내 채널 분석" / "경쟁 채널 분석"
  * MyChannelTab 컴포넌트로 개인 채널용 상세 대시보드 제공(채널 요약, 톤앤매너, 콘텐츠 구조, 성장 기회)

* **개선**
  * 긴 대본(자막) 자동 샘플링 도입으로 과도한 길이 처리 개선
  * LLM 기반 분석 엔진 업데이트로 분석 정확성 및 응답 처리 개선

* **리팩터**
  * 일부 분석 UI 컴포넌트 및 타입을 공개(export)하여 재사용성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->